### PR TITLE
Addional env-format option for add-from-env cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ FOO=bar
 ```
 
 Where `/var/lib/genesis/app.env` is default path.
+There are two supported formats for the env file: `env` and `json`, use option `--env-format` to set the format.
 
 In the `plain text` we need to specify at least two variables for path and content.
 

--- a/genesis_ci_tools/cmd/cli.py
+++ b/genesis_ci_tools/cmd/cli.py
@@ -25,6 +25,7 @@ from gcl_sdk.clients.http import base as http_client
 
 from genesis_ci_tools import config as config_lib
 from genesis_ci_tools import node as node_lib
+from genesis_ci_tools import constants as c
 
 
 class CmdContext(tp.NamedTuple):
@@ -453,6 +454,13 @@ def list_config_cmd(
     help="Path to the env file will be saved on the node",
 )
 @click.option(
+    "--env-format",
+    default="env",
+    type=click.Choice([s for s in tp.get_args(c.ENV_FILE_FORMAT)]),
+    show_default=True,
+    help="Format of the env file",
+)
+@click.option(
     "--cfg-prefix",
     default="GCT_CFG_",
     help="Prefix used to filter environment variables for configs",
@@ -470,6 +478,7 @@ def add_config_from_env_cmd(
     project_id: sys_uuid.UUID,
     env_prefix: str,
     env_path: str,
+    env_format: c.ENV_FILE_FORMAT,
     cfg_prefix: str,
     base64: bool,
     node: sys_uuid.UUID,
@@ -480,6 +489,7 @@ def add_config_from_env_cmd(
         project_id,
         env_prefix,
         env_path,
+        env_format,
         cfg_prefix,
         base64,
         node,

--- a/genesis_ci_tools/config.py
+++ b/genesis_ci_tools/config.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+import json
 import base64 as base64_lib
 import typing as tp
 import uuid as sys_uuid
@@ -25,6 +26,7 @@ import click
 from gcl_sdk.clients.http import base as http_client
 
 from genesis_ci_tools import logger
+from genesis_ci_tools import constants as c
 
 
 def list_config(
@@ -46,6 +48,7 @@ def add_config_from_env(
     project_id: sys_uuid.UUID,
     env_prefix: str,
     env_path: str,
+    env_format: c.ENV_FILE_FORMAT,
     cfg_prefix: str,
     base64: bool,
     node: sys_uuid.UUID,
@@ -64,7 +67,13 @@ def add_config_from_env(
             envs[key] = value
 
     if envs:
-        content = "\n".join([f"{k}={v}" for k, v in envs.items()])
+        if env_format == "env":
+            content = "\n".join([f"{k}={v}" for k, v in envs.items()])
+        elif env_format == "json":
+            content = json.dumps(envs, indent=2)
+        else:
+            raise ValueError(f"Unknown env format {env_format}")
+
         client.create(
             "/v1/config/configs/",
             data={

--- a/genesis_ci_tools/constants.py
+++ b/genesis_ci_tools/constants.py
@@ -1,0 +1,19 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import typing as tp
+
+ENV_FILE_FORMAT = tp.Literal["json", "env"]


### PR DESCRIPTION
A new `--env-format` option was added that accept env file format. Threre are two supported formats:
- json
- env

The `json` format is obvious, the `env` format means:
```ini
key1=value1
key2=value2
```