### PR TITLE
Support of element upgrading

### DIFF
--- a/genesis_ci_tools/cmd/cli.py
+++ b/genesis_ci_tools/cmd/cli.py
@@ -681,6 +681,43 @@ def install_element_cmd(
     log.important(f"Element {manifest['name']} installed successfully")
 
 
+@elements_group.command("update", help="Update element from a YAML file")
+@click.option(
+    "-r",
+    "--repository",
+    default="http://10.20.0.1:8080/genesis-elements/",
+    show_default=True,
+    help="Repository endpoint",
+)
+@click.argument("path_or_name")
+@click.pass_context
+def update_element_cmd(
+    ctx: click.Context, repository: str, path_or_name: str
+) -> None:
+    """Update element from a YAML file"""
+    client: http_client.CollectionBaseClient = ctx.obj.client
+    log = logger.ClickLogger()
+
+    if os.path.exists(path_or_name):
+        with open(path_or_name, "r", encoding="utf-8") as f:
+            manifest = yaml.safe_load(f)
+    else:
+        manifest = repo_lib.download_manifest(repository, path_or_name)
+
+    # TODO(akremenetsky): Resolve new dependencies
+
+    manifest_uuid = elements_lib.get_manifest_uuid(client, manifest)
+
+    manifests = elements_lib.list_manifest(client, name=manifest["name"])
+    if manifests:
+        elements_lib.delete_manifest(client, manifest_uuid)
+
+    elements_lib.add_manifest(client, manifest)
+    elements_lib.apply_manifest(client, manifest_uuid)
+
+    log.important(f"Element {manifest['name']} updated successfully")
+
+
 @elements_group.command(
     "uninstall", help="Uninstall element by UUID, path or name"
 )

--- a/genesis_ci_tools/elements.py
+++ b/genesis_ci_tools/elements.py
@@ -32,6 +32,31 @@ def list_manifest(
     return client.filter(c.MANIFEST_COLLECTION, **filters)
 
 
+def get_manifest_uuid(
+    client: http_client.CollectionBaseClient,
+    manifest: dict[str, tp.Any],
+) -> sys_uuid.UUID:
+    # Try to get manifest by name
+    if "uuid" not in manifest:
+        if "name" not in manifest:
+            raise click.ClickException("Manifest must have a name")
+        manifests = list_manifest(client, name=manifest["name"])
+
+        if not manifests:
+            raise click.ClickException(
+                f"Manifest '{manifest['name']}' not found"
+            )
+
+        if len(manifests) > 1:
+            raise click.ClickException(
+                f"Multiple manifests found for '{manifest['name']}'"
+            )
+
+        return sys_uuid.UUID(manifests[0]["uuid"])
+
+    return sys_uuid.UUID(manifest["uuid"])
+
+
 def add_manifest(
     client: http_client.CollectionBaseClient,
     manifest: dict[str, tp.Any],
@@ -46,6 +71,27 @@ def add_manifest(
         manifest_resp = client.create(c.MANIFEST_COLLECTION, data=manifest)
     except bazooka_exc.ConflictError:
         raise click.ClickException(f"Manifest with UUID {uuid} already exists")
+
+    return manifest_resp
+
+
+def update_manifest(
+    client: http_client.CollectionBaseClient,
+    manifest: dict[str, tp.Any],
+) -> dict[str, tp.Any]:
+    uuid = get_manifest_uuid(client, manifest)
+
+    # Remove fields that are not allowed to be updated
+    data = manifest.copy()
+    data.pop("uuid", None)
+    data.pop("version", None)
+    data.pop("name", None)
+    data.pop("schema_version", None)
+
+    try:
+        manifest_resp = client.update(c.MANIFEST_COLLECTION, uuid=uuid, **data)
+    except bazooka_exc.NotFoundError:
+        raise click.ClickException(f"Manifest with UUID {uuid} not found")
 
     return manifest_resp
 
@@ -71,6 +117,20 @@ def install_manifest(
     except bazooka_exc.ConflictError:
         raise click.ClickException(
             f"Manifest with UUID {uuid} already installed"
+        )
+
+
+def apply_manifest(
+    client: http_client.CollectionBaseClient,
+    uuid: sys_uuid.UUID,
+) -> None:
+    try:
+        client.do_action(
+            c.MANIFEST_COLLECTION, uuid=uuid, name="upgrade", invoke=True
+        )
+    except bazooka_exc.NotFoundError:
+        raise click.ClickException(
+            f"Manifest with UUID {uuid} is not installed"
         )
 
 


### PR DESCRIPTION
CLI:
- The new `element update` command added. The syntax is similar to `install` command.

Element lib:
- get_manifest_uuid - Fetch UUID from manifest spec or fetch by name.
- update_manifest - Wrapper around update API call.
- apply_manifest - Wrapper around upgrade API call.